### PR TITLE
Fix typo in App alias

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -193,7 +193,7 @@ return [
         'Validator' => Illuminate\Support\Facades\Validator::class,
         'View'      => Illuminate\Support\Facades\View::class,
         'Form'      => Collective\Html\FormFacade::class,
-        'Html'      => Collective\Html\HtmlFacade::class,
+        'HTML'      => Collective\Html\HtmlFacade::class,
 
     ],
 


### PR DESCRIPTION
Em dùng alias class là HTML nhưng khi config alias trong app là Html  ( sau chữ cái đầu viết hoa còn lại là viết thường) nên app bị lỗi không tìm thấy class HTML 
